### PR TITLE
Allow vlan list for tx definitions; make change

### DIFF
--- a/src/gobbler/config_test.c
+++ b/src/gobbler/config_test.c
@@ -1,5 +1,5 @@
-/*
-	Mneminic:	config_test.c
+		/*
+		Mneminic:	config_test.c
 	Abstract: 	Unit test for config.c module.
 				Tests obvious things, may miss edge cases.
 	Date:		07 May 2017
@@ -26,15 +26,32 @@
 
 static void print_cfg( config_t* cfg ) {
 	int i;
+	int j;
+	vlan_set_t* vs;
 
 	fprintf( stderr, "\t rx_devs: [ " );
 	for( i = 0; i < cfg->nrx_devs; i++ ) {
 		fprintf( stderr, " \"%s\" ",	cfg->rx_devs[i] );				
 	}
 	fprintf( stderr, " ]\n" );
+
 	fprintf( stderr, "\t tx_devs: [ " );
 	for( i = 0; i < cfg->ntx_devs; i++ ) {
 		fprintf( stderr, " \"%s\" ",	cfg->tx_devs[i] );				
+	}
+	fprintf( stderr, " ]\n" );
+
+	fprintf( stderr, "\t tx vlan sets: [ " );
+	for( i = 0; i < cfg->ntx_devs; i++ ) {
+		if( (vs = cfg->vlans[i] ) != NULL ) {
+			fprintf( stderr, " [ " );
+			for( j = 0; j < vs->nvlans; j++ ) {
+				fprintf( stderr, " %d",	vs->vlans[j] );				
+			}
+			fprintf( stderr, " ] " );
+		} else {
+			fprintf( stderr, " [ ] " );
+		}
 	}
 	fprintf( stderr, " ]\n" );
 
@@ -79,7 +96,7 @@ int main( int argc, char** argv ) {
 		);
 	}
 
-	cfg = crack_args( argc, argv );
+	cfg = crack_args( argc, argv, fname );		// open file, fname if -c not supplied
 	if( cfg == NULL ) {
 		fprintf( stderr, "[FAIL] unable to read and/or parse config file %s: %s\n", fname, strerror( errno ) );
 		rc = 1;

--- a/src/gobbler/crack_args.c
+++ b/src/gobbler/crack_args.c
@@ -57,9 +57,10 @@ static char* get_nxt( int argc, char** argv, int* pidx ) {
 			-inc /path/cfgfile
 			-i -c /path/cfgfile -n
 			-ni -c /path/cfg
+
+	The cfg_fname parm is the default filename used if -c is not supplied. 
 */
-extern config_t* crack_args( int argc, char** argv ) {
-	char*	cfg_fname = NULL;
+extern config_t* crack_args( int argc, char** argv, char const* cfg_fname ) {
 	config_t*	cfg;
 	int		async = 1;			// -i keeps this interactive and attached to the tty
 	int		forreal = 1;		// -n sets this to 0 preventing destructive things
@@ -69,9 +70,6 @@ extern config_t* crack_args( int argc, char** argv ) {
 	int		flags;
 	int		dump_size = 0;
 	
-
-	cfg_fname = strdup( "/etc/switchboard/anolis.cfg" );			// default config if -c missing
-
 	// we pull config from a file, not command line, so parse just the minimal things that 
 	// need to come from the command line. We'll build a 'dpdk parsable' argv/argc later 
 	// and pretend we got it from the command line.
@@ -113,7 +111,6 @@ extern config_t* crack_args( int argc, char** argv ) {
 			}
 		}
 	}
-
 
 	cfg = read_config( cfg_fname );
 	if( cfg == NULL ) {

--- a/src/gobbler/gobbler.h
+++ b/src/gobbler/gobbler.h
@@ -114,6 +114,16 @@ typedef struct if_stats {
 	int64_t cadds;
 } if_stats_t;
 
+
+/*
+	Manages a set of VLAN IDs that we rotate through when we Tx on a device
+*/
+typedef struct vlan_set {
+	uint16_t*	vlans;			// the array of IDs we loop through
+	uint32_t	idx;			// index into the array
+	uint32_t	nvlans;			// number in the list
+} vlan_set_t;
+
 /*
 	Describes an interface (pci we assume) and maps it to a port in dpdk terms.
 */
@@ -127,6 +137,7 @@ typedef struct iface {
 	int nrxq;
 	int	ntxdesc;							// number of descriptors to allocate
 	int nrxdesc;
+	vlan_set_t	*vset;						// a list of VLAN IDs that are rotated through when Txing to this dev
 	uint64_t last_clock;					// clock value of last flush
 	struct ether_addr gate;					// router/gateway mac address to send routable packets to on this interface
 	struct ether_addr mac_addr;				// the mac address of this port in dpdk form
@@ -148,7 +159,8 @@ typedef struct config {
 	int		nrx_devs;				// number in each array
 	int		ntx_devs;
 	int*	rx_ports;				// port numbers corresponding to the rx_devs names
-	int*	tx_ports;				// tx numbers
+	int*	tx_ports;				// tx port numbers
+	vlan_set_t** vlans;				// vlans per tx dev (order matches tx_ports order)
 
 	char*	log_dir;
 	char*	log_file;				// fully qualified log file name to give to bleat
@@ -215,7 +227,7 @@ typedef struct context {
 
 
 //---- config things ------------------------------------------------------
-extern config_t* crack_args( int argc, char** argv );
+extern config_t* crack_args( int argc, char** argv, char const* def_fname );
 extern void free_config( config_t* config );
 extern config_t* read_config( char const* fname );
 


### PR DESCRIPTION
Changes to config processing allow a list of vlans to be given for each tx dev defined allowing forwarded packets to be given different vlan IDs.  This allows easier testing of spoofing and multiple vlan support.